### PR TITLE
Add thumbnail parser wrapper and unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+use scraper::{Html, Selector};
+use std::io::Result;
+
+/// Extract thumbnail URL from provided HTML body using the same logic as
+/// `get_thumbnail_url_from_rj`.
+pub fn get_thumbnail_url_from_html(body: &str) -> Option<String> {
+    let document = Html::parse_document(body);
+    document
+        .select(&Selector::parse("#img_cover").unwrap())
+        .next()
+        .and_then(|e| e.value().attr("href"))
+        .or_else(|| {
+            document
+                .select(&Selector::parse("#img_cover img").unwrap())
+                .next()
+                .and_then(|e| e.value().attr("data-src"))
+        })
+        .map(|s| s.to_string())
+}
+
+/// Fetch the given URL and attempt to extract the thumbnail URL from the page.
+pub async fn get_thumbnail_url_from_rj(url: &str) -> Result<Option<String>> {
+    let body = reqwest::get(url)
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .text()
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    Ok(get_thumbnail_url_from_html(&body))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 use async_std::io::WriteExt;
-use scraper::Html;
-use scraper::Selector;
 use std::{env, error::Error, io::Result};
 use rjasmr::get_thumbnail_url_from_rj;
 
@@ -142,14 +140,8 @@ pub fn embed_thumbnail(file_path: &str, image_data: &[u8]) -> std::result::Resul
 
 pub async fn get_audio_response(page_url: &str) -> std::result::Result<reqwest::Response, Box<dyn Error>> {
     let body = reqwest::get(page_url).await?.text().await?;
-    let document = Html::parse_document(&body);
-    let selector = Selector::parse("video>source").unwrap();
-
-    let audio_url = document.select(&selector)
-    .filter_map(|e| e.value().attr("src"))
-    .map(|s| s.to_string())
-    .next()
-    .ok_or("No audio source with a 'src' attribute found inside a <video> tag.")?;
+    let audio_url = rjasmr::get_audio_url_from_html(&body)
+        .ok_or("No audio source with a 'src' attribute found inside a <video> tag.")?;
 
     println!("Found audio link: {}", audio_url);
 

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,0 +1,15 @@
+use rjasmr::get_audio_url_from_html;
+
+#[async_std::test]
+async fn audio_from_video_sources() {
+    let html = r#"
+        <div id="cleanp_audio" class="cleanPlayer" theme="dark">
+        <video title="Track 1" descr="Track 1" preload="metadata" poster="https://pic.weeabo0.xyz/RJ284161_img_main.jpg">
+        <source src="https://v.weeab0o.xyz/RJ284161.mp3" type="audio/mpeg"/>
+        <source src="https://v.weeab0o.xyz/RJ284161.m4a" type="audio/mp4"/>
+        </video>
+        </div>
+    "#;
+    let url = get_audio_url_from_html(html);
+    assert_eq!(url.as_deref(), Some("https://v.weeab0o.xyz/RJ284161.mp3"));
+}

--- a/tests/thumbnail.rs
+++ b/tests/thumbnail.rs
@@ -4,7 +4,7 @@ use rjasmr::get_thumbnail_url_from_html;
 async fn thumbnail_from_anchor_href() {
     let html = r#"
         <html><body>
-        <a id=\"img_cover\" href=\"https://example.com/thumb.jpg\">cover</a>
+        <a id="img_cover" href="https://example.com/thumb.jpg">cover</a>
         </body></html>
     "#;
     let url = get_thumbnail_url_from_html(html);
@@ -15,7 +15,7 @@ async fn thumbnail_from_anchor_href() {
 async fn thumbnail_from_img_data_src() {
     let html = r#"
         <html><body>
-        <div id=\"img_cover\"><img data-src=\"https://example.com/img.jpg\" /></div>
+        <div id="img_cover"><img data-src="https://example.com/img.jpg" /></div>
         </body></html>
     "#;
     let url = get_thumbnail_url_from_html(html);

--- a/tests/thumbnail.rs
+++ b/tests/thumbnail.rs
@@ -1,0 +1,23 @@
+use rjasmr::get_thumbnail_url_from_html;
+
+#[async_std::test]
+async fn thumbnail_from_anchor_href() {
+    let html = r#"
+        <html><body>
+        <a id=\"img_cover\" href=\"https://example.com/thumb.jpg\">cover</a>
+        </body></html>
+    "#;
+    let url = get_thumbnail_url_from_html(html);
+    assert_eq!(url.as_deref(), Some("https://example.com/thumb.jpg"));
+}
+
+#[async_std::test]
+async fn thumbnail_from_img_data_src() {
+    let html = r#"
+        <html><body>
+        <div id=\"img_cover\"><img data-src=\"https://example.com/img.jpg\" /></div>
+        </body></html>
+    "#;
+    let url = get_thumbnail_url_from_html(html);
+    assert_eq!(url.as_deref(), Some("https://example.com/img.jpg"));
+}

--- a/tests/thumbnail.rs
+++ b/tests/thumbnail.rs
@@ -21,3 +21,15 @@ async fn thumbnail_from_img_data_src() {
     let url = get_thumbnail_url_from_html(html);
     assert_eq!(url.as_deref(), Some("https://example.com/img.jpg"));
 }
+
+#[async_std::test]
+async fn thumbnail_from_img_content() {
+    let html = r#"
+        <div class="img-content img-display-container">
+        <img class="imgSlides lazyload lazy" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%201%201'%3E%3C/svg%3E" data-src="https://pic.weeabo0.xyz/RJ284161_img_main.jpg"  style="width:100%" />
+        <img class="imgSlides lazyload lazy" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%201%201'%3E%3C/svg%3E" data-src="https://pic.weeabo0.xyz/RJ284161(1).jpg"  style="width:100%">
+        </div>
+    "#;
+    let url = get_thumbnail_url_from_html(html);
+    assert_eq!(url.as_deref(), Some("https://pic.weeabo0.xyz/RJ284161_img_main.jpg"));
+}


### PR DESCRIPTION
## Summary
- expose thumbnail scraping logic in new `get_thumbnail_url_from_html` helper
- use helper in `get_thumbnail_url_from_rj` and update binary
- add integration tests covering both `<a href>` and `<img data-src>` cases

## Testing
- `cargo test` *(fails: failed to download crates)*
- `cargo build` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68498d2c53f08322a9911e9973b3e6cd